### PR TITLE
includes associations to reduce the migration time taken by n + 1 queries

### DIFF
--- a/core/db/migrate/20130807024301_upgrade_adjustments.rb
+++ b/core/db/migrate/20130807024301_upgrade_adjustments.rb
@@ -5,7 +5,7 @@ class UpgradeAdjustments < ActiveRecord::Migration
       belongs_to :originator, polymorphic: true
     end
     # Shipping adjustments are now tracked as fields on the object
-    Spree::Adjustment.where(:source_type => "Spree::Shipment").find_each do |adjustment|
+    Spree::Adjustment.includes(:source).where(:source_type => "Spree::Shipment").find_each do |adjustment|
       # Account for possible invalid data
       next if adjustment.source.nil?
       adjustment.source.update_column(:cost, adjustment.amount)
@@ -20,7 +20,7 @@ class UpgradeAdjustments < ActiveRecord::Migration
     end
 
     # Promotion adjustments have their source altered also
-    Spree::Adjustment.where(:originator_type => "Spree::PromotionAction").find_each do |adjustment|
+    Spree::Adjustment.includes(:source, originator: :calculator).where(:originator_type => "Spree::PromotionAction").find_each do |adjustment|
       next if adjustment.originator.nil?
       adjustment.source = adjustment.originator
       begin


### PR DESCRIPTION
Migration is taking too much time due to **`n + 1 queries`**

```
With includes:       0.360000   0.000000   0.360000 (  0.384775)
Without includes:  2.850000   0.120000   2.970000 (  4.137901)

```